### PR TITLE
Use enum to represent days

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ and this to your crate root:
 
 ```rust
 extern crate dow;
+use dow::Day;
 ```
 
 and then you can use it as follows:
 
 ```rust
 let day_index = dow::dow(2017, 7, 2);
-assert_eq!(day_index, 0);
+assert_eq!(day_index, Day::Sunday);
 ```
-
-Note: Sunday is `0`, Monday is `1` etc.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ use dow::Day;
 and then you can use it as follows:
 
 ```rust
-let day_index = dow::dow(2017, 7, 2);
-assert_eq!(day_index, Day::Sunday);
+let day = dow::dow(2017, 7, 2);
+assert_eq!(day, Day::Sunday);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub enum Day {
 }
 
 pub fn dow(y: usize, m: usize, d: usize) -> Day {
-    /// Return the index of the day for which the given date corresponds to.
+    /// Return the day which the given date corresponds to.
     ///
     /// # Arguments
     ///
@@ -29,8 +29,8 @@ pub fn dow(y: usize, m: usize, d: usize) -> Day {
     /// extern crate dow;
     /// use dow::Day;
     ///
-    /// let day_index = dow::dow(2017, 7, 2);
-    /// assert_eq!(day_index, Day::Sunday);
+    /// let day = dow::dow(2017, 7, 2);
+    /// assert_eq!(day, Day::Sunday);
     /// ```
 
     let mut yy = y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,37 +3,57 @@
 /// Lookup table for day indices.
 const LOOKUP: [usize; 12] = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
 
-/// Return the index of the day for which the given date corresponds to.
-///
-/// # Arguments
-/// 
-/// * `y`: Year
-/// * `m`: Month
-/// * `d`: Day
-///
-/// # Example
-///
-/// ```
-/// extern crate dow;
-///
-/// let day_index = dow::dow(2017, 7, 2);
-/// assert_eq!(day_index, 0); // 2017/07/02 is a Sunday
-/// ```
-///
-/// # Note
-///
-///	Sunday is `0`, Monday is `1` etc.
-pub fn dow(y: usize, m: usize, d: usize) -> usize {
+#[derive(Debug, PartialEq)]
+pub enum Day {
+    Sunday,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday
+}
+
+pub fn dow(y: usize, m: usize, d: usize) -> Day {
+    /// Return the index of the day for which the given date corresponds to.
+    ///
+    /// # Arguments
+    ///
+    /// * `y`: Year
+    /// * `m`: Month
+    /// * `d`: Day
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate dow;
+    /// use dow::Day;
+    ///
+    /// let day_index = dow::dow(2017, 7, 2);
+    /// assert_eq!(day_index, Day::Sunday);
+    /// ```
+
     let mut yy = y;
 
     if m < 3 {
         yy -= 1;
     }
 
-    (yy + yy / 4 - yy / 100 + yy / 400 + LOOKUP[m - 1] + d) % 7
+    let day = (yy + yy / 4 - yy / 100 + yy / 400 + LOOKUP[m - 1] + d) % 7;
+    match day {
+        0 => Day::Sunday,
+        1 => Day::Monday,
+        2 => Day::Tuesday,
+        3 => Day::Wednesday,
+        4 => Day::Thursday,
+        5 => Day::Friday,
+        6 => Day::Saturday,
+        _ => unreachable!()
+    }
 }
+
 
 #[test]
 fn it_works() {
-    assert_eq!(dow(2017, 7, 2), 0);
+    assert_eq!(dow(2017, 7, 2), Day::Sunday);
 }


### PR DESCRIPTION
I feel using an enum to represent the day would be more ergonomic. This would hinder backwards compatibility, but maybe an additional method could be added if that's desired.